### PR TITLE
Use RabbitMQ service name to address ephemeral pod IP issue

### DIFF
--- a/converter_streams/Converter.py
+++ b/converter_streams/Converter.py
@@ -402,7 +402,7 @@ def generate_queue(queue, application):
         "curl -u user:"
         + password
         + " -X PUT "
-        + ip
+        + "localhost"
         + ":30298/api/queues/"
         + application
         + "/"

--- a/converter_streams/Converter.py
+++ b/converter_streams/Converter.py
@@ -303,6 +303,7 @@ def tosca_to_k8s(operator_list, host_list, namespace_pack):
                     persistent_volumes.append(pv)
                     persistent_volumes.append(pvc)
                 ip = os.getenv("POD_IP", "ip")
+                ip = "mu-rabbit-rabbitmq.rabbit.svc.cluster.local"
                 password = os.getenv("RABBITMQ_PASSWORD", "password")
                 queues = y.get_queues()
                 properties = queues.get("properties")

--- a/converter_streams/Converter.py
+++ b/converter_streams/Converter.py
@@ -375,14 +375,17 @@ def namespace(application):
     }
     password = os.getenv("RABBITMQ_PASSWORD", "password")
     ip = os.getenv("POD_IP", "ip")
+    # SOLVED: rabbitmq loadbalancer service expose the 30298 port, forward to 15672
+    # SOLVED : can use localhost as ip
     command = (
         "curl -u user:"
         + password
         + " -X PUT "
-        + ip
-        + ":15672/api/vhosts/"
+        + "localhost"
+        + ":30298/api/vhosts/"
         + application
     )
+    # curl -u user:xw -X PUT http://localhost:30298/api/vhosts/axl2
     print(str(command))
     subprocess.call([str(command)], shell=True)
 
@@ -393,12 +396,14 @@ def generate_queue(queue, application):
     password = os.getenv("RABBITMQ_PASSWORD", "password")
     parameters = {"durable": True}
     ip = os.getenv("POD_IP", "ip")
+    # SOLVED: rabbitmq loadbalancer service expose the 30298 port, forward to 15672
+    # SOLVED : can use localhost as ip
     command = (
         "curl -u user:"
         + password
         + " -X PUT "
         + ip
-        + ":15672/api/queues/"
+        + ":30298/api/queues/"
         + application
         + "/"
         + queue
@@ -407,6 +412,7 @@ def generate_queue(queue, application):
         + json.dumps(parameters)
         + "'"
     )
+    # curl -u user:xw -X PUT http://localhost:30298/api/queues/axl2/simpleq --data '{"durable":true}'
     print(str(command))
     subprocess.call([str(command)], shell=True)
 

--- a/converter_streams/KEDA.py
+++ b/converter_streams/KEDA.py
@@ -84,6 +84,8 @@ def write_rules_config(operatorlist, dirpath):
 
         password = os.getenv("RABBITMQ_PASSWORD", "password")
         ip = os.getenv("POD_IP", "ip")
+        # use the rabbitmq Cluster IP instead of the POD IP
+        ip = "mu-rabbit-rabbitmq.rabbit.svc.cluster.local"
         username = "user"
         uri = f"http://{username}:{password}@{ip}:15672/{namespace}"
 


### PR DESCRIPTION
- for vhost and queue creation, use the port exposed by rabbit LoadBalancer service. Please check which port exposed by that service before defining the port on Converter.py (line 386 and 407)
